### PR TITLE
Fix warnings from unused packages

### DIFF
--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using UnityEditor;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System;

--- a/Examples/TestUberLogger.cs
+++ b/Examples/TestUberLogger.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using System.Collections;
 using System.Collections.Generic;
 
 public class TestUberLogger : MonoBehaviour

--- a/UberDebug.cs
+++ b/UberDebug.cs
@@ -1,8 +1,3 @@
-using UnityEngine;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System;
 using UberLogger;
 
 //Helper functions to make logging easier

--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System;

--- a/UberLoggerAppWindow.cs
+++ b/UberLoggerAppWindow.cs
@@ -1,7 +1,5 @@
 using UnityEngine;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System;
 using UberLogger;
 

--- a/UberLoggerEditor.cs
+++ b/UberLoggerEditor.cs
@@ -1,6 +1,5 @@
 #if UNITY_EDITOR
 using UnityEngine;
-using System.Collections;
 using System.Collections.Generic;
 using System;
 using UnityEditor;

--- a/UberLoggerFile.cs
+++ b/UberLoggerFile.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UberLogger;
 using System.IO;
 using UnityEngine;


### PR DESCRIPTION
Just a quick fixup to get rid of warnings caused by unused imported packages.
