### PR TITLE
Background thread usage

### DIFF
--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -193,7 +193,7 @@ namespace UberLogger
 
         static List<ILogger> Loggers = new List<ILogger>();
         static LinkedList<LogInfo> RecentMessages = new LinkedList<LogInfo>();
-        static double StartTime;
+        static long StartTick;
         static bool AlreadyLogging = false;
         static Regex UnityMessageRegex;
 
@@ -205,7 +205,7 @@ namespace UberLogger
 #else
             Application.RegisterLogCallback(UnityLogHandler);
 #endif
-            StartTime = GetTime();
+            StartTick = DateTime.Now.Ticks;
             UnityMessageRegex = new Regex(@"(.*)\((\d+).*\)");
         }
 
@@ -220,12 +220,8 @@ namespace UberLogger
     
         static public double GetTime()
         {
-#if UNITY_EDITOR
-            return EditorApplication.timeSinceStartup - StartTime;
-#else
-            double time = Time.time;
-            return time - StartTime;
-#endif
+            long ticks = DateTime.Now.Ticks;
+            return TimeSpan.FromTicks(ticks - StartTick).TotalSeconds;
         }
 
         /// <summary>

--- a/UberLoggerEditor.cs
+++ b/UberLoggerEditor.cs
@@ -96,7 +96,6 @@ public class UberLoggerEditor : ScriptableObject, UberLogger.ILogger
             Channels.Add(logInfo.Channel);
         }
 
-        ProcessOnStartClear();
         LogInfo.Add(logInfo);
         if(logInfo.Severity==LogSeverity.Error)
         {


### PR DESCRIPTION
I discovered some problems while calling the logging functions from a background thread. I wondered whether this was out of scope, but the read says the intention is to be thread safe so I thought I'd fix it :smile:

There were 2 issues:
```
get_timeSinceStartup can only be called from the main thread.
Constructors and field initializers will be executed from the loading thread when loading a scene.
Don't use this function in the constructor or field initializers, instead move initialization code to the Awake or Start function.
  at (wrapper managed-to-native) UnityEditor.EditorApplication:get_timeSinceStartup ()
  at UberLogger.Logger.GetTime () [0x00001] in /path/to/UberLogger/UberLogger.cs:224 
  at UberLogger.LogInfo..ctor (UnityEngine.Object source, System.String channel, LogSeverity severity, System.Collections.Generic.List`1 callstack, System.Object message, System.Object[] par) [0x00085] in /path/to/UberLogger/UberLogger.cs:177 
  at UberLogger.Logger.Log (System.String channel, UnityEngine.Object source, LogSeverity severity, System.Object message, System.Object[] par) [0x00048] in /path/to/UberLogger/UberLogger.cs:437 
  at UberDebug.LogWarning (System.Object message, System.Object[] par) [0x0000a] in /path/to/UberLogger/UberDebug.cs:40 
```
In editor mode it was `get_timeSinceStartup`, at play time `get_time` had the same error. I fixed this by using `DateTime.Now.Ticks` as a source instead.

The second problem is this:
```
get_isPlayingOrWillChangePlaymode can only be called from the main thread.
Constructors and field initializers will be executed from the loading thread when loading a scene.
Don't use this function in the constructor or field initializers, instead move initialization code to the Awake or Start function.
  at (wrapper managed-to-native) UnityEditor.EditorApplication:get_isPlayingOrWillChangePlaymode ()
  at UberLoggerEditor.ProcessOnStartClear () [0x0002c] in /path/to/UberLogger/UberLoggerEditor.cs:59 
  at UberLoggerEditor.Log (UberLogger.LogInfo logInfo) [0x0003c] in /path/to/UberLogger/UberLoggerEditor.cs:99 
  at UberLogger.Logger+<Log>c__AnonStorey1.<>m__0 (ILogger l) [0x00007] in /path/to/UberLogger/UberLogger.cs:443 
  at System.Collections.Generic.List`1[UberLogger.ILogger].ForEach (System.Action`1 action) [0x00018] in /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Collections.Generic/List.cs:361 
  at UberLogger.Logger.Log (System.String channel, UnityEngine.Object source, LogSeverity severity, System.Object message, System.Object[] par) [0x000a1] in /path/to/UberLogger/UberLogger.cs:443 
  at UberDebug.LogWarning (System.Object message, System.Object[] par) [0x0000a] in /path/to/UberLogger/UberDebug.cs:40 
```

This was because `UberLoggerEditor.Log` was always calling `ProcessOnStartClear`. My workaround is to stop doing that 😉 I'm not sure why it was needed since the `playmodeStateChanged` event should cover it? I can't see a way of making that method work in background threads without skipping that. 

Hopefully this is useful! Logging from a thread worked fine once I'd made these changes.