### PR TITLE
Double clicking on a line shows source code immediately

### DIFF
--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -444,7 +444,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
                 //Select a message, or jump to source if it's double-clicked
                 if(renderLogIndex==SelectedRenderLog)
                 {
-                    if(EditorApplication.timeSinceStartup-LastMessageClickTime<0.3f)
+                    if(EditorApplication.timeSinceStartup-LastMessageClickTime<DoubleClickInterval)
                     {
                         LastMessageClickTime = 0;
                         if(log.Callstack.Count>0)
@@ -461,7 +461,9 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
                 {
                     SelectedRenderLog = renderLogIndex;
                     SelectedCallstackFrame = -1;
+                    LastMessageClickTime = EditorApplication.timeSinceStartup;
                 }
+
 
                 //Always select the game object that is the source of this message
                 var go = log.Source as GameObject;
@@ -583,7 +585,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
                             }
                             else
                             {
-                                if(EditorApplication.timeSinceStartup-LastFrameClickTime<0.3f)
+                                if(EditorApplication.timeSinceStartup-LastFrameClickTime<DoubleClickInterval)
                                 {
                                     LastFrameClickTime = 0;
                                     JumpToSource(frame);
@@ -598,6 +600,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
                         else
                         {
                             SelectedCallstackFrame = c1;
+                            LastFrameClickTime = EditorApplication.timeSinceStartup;
                         }
                     }
                     lineY += lineHeight;
@@ -834,6 +837,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
     double LastMessageClickTime = 0;
     double LastFrameClickTime = 0;
 
+    const double DoubleClickInterval = 0.3f;
 
     //Serialise the logger field so that Unity doesn't forget about the logger when you hit Play
     [UnityEngine.SerializeField]


### PR DESCRIPTION
Hi,

first time contributor here.

One usability thing that is annoying to me is: if I want to view the source code associated with a message or a stack frame, I first need to select the message or stack frame, and then perform a double-click on the same entry. (A triple-click would also work.)

This change makes it so that a double-click on a not-already-selected entry will open source code view.
In other words:
single click on entry = move focus to entry
double click on entry = view corresponding source code
... regardless of which element is in focus before.