### PR TITLE
When double-clicking on a message, search for the first viewable stackframe

### DIFF
--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -447,9 +447,12 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
                     if(EditorApplication.timeSinceStartup-LastMessageClickTime<0.3f)
                     {
                         LastMessageClickTime = 0;
-                        if(log.Callstack.Count>0)
+                        // Attempt to display source code associated with messages. Search through all stackframes,
+                        //   until we find a stackframe that can be displayed in source code view
+                        for (int frame = 0; frame < log.Callstack.Count; frame++)
                         {
-                            JumpToSource(log.Callstack[0]);
+                            if (JumpToSource(log.Callstack[frame]))
+                                break;
                         }
                     }
                     else
@@ -642,13 +645,16 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
         ShowFrameSource = !ShowFrameSource;
     }
 
-    void JumpToSource(LogStackFrame frame)
+    bool JumpToSource(LogStackFrame frame)
     {
         var filename = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), frame.FileName);
         if (System.IO.File.Exists(filename))
         {
-            UnityEditorInternal.InternalEditorUtility.OpenFileAtLineExternal(frame.FileName, frame.LineNumber);
+            if (UnityEditorInternal.InternalEditorUtility.OpenFileAtLineExternal(frame.FileName, frame.LineNumber))
+                return true;
         }
+
+        return false;
     }
 
     GUIContent GetFrameSourceGUIContent(LogStackFrame frame)

--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -647,11 +647,14 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
 
     bool JumpToSource(LogStackFrame frame)
     {
-        var filename = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), frame.FileName);
-        if (System.IO.File.Exists(filename))
+        if (frame.FileName != null)
         {
-            if (UnityEditorInternal.InternalEditorUtility.OpenFileAtLineExternal(frame.FileName, frame.LineNumber))
-                return true;
+            var filename = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), frame.FileName);
+            if (System.IO.File.Exists(filename))
+            {
+                if (UnityEditorInternal.InternalEditorUtility.OpenFileAtLineExternal(frame.FileName, frame.LineNumber))
+                    return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
Begin search at the top of the callstack. If the top fails to open, try the next one, etc.

This avoids the problem where you double-click on a message, the first stack frame is in glue code (like DebugHandler.Internal_Log), where source code is not available. With this in place, the default configuration of UberLogger makes double clicking on a message jump straight to the Debug.Log line which produced the message.