### PR TITLE
Split Unity callstacks with both System.Environment.NewLine and \n separators

### DIFF
--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -328,7 +328,15 @@ namespace UberLogger
         /// </summary>
         static List<LogStackFrame> GetCallstackFromUnityLog(string unityCallstack)
         {
-            var lines = System.Text.RegularExpressions.Regex.Split(unityCallstack, System.Environment.NewLine); 
+            // First, split lines using OS-native line ending
+            var lines = System.Text.RegularExpressions.Regex.Split(unityCallstack, System.Environment.NewLine);
+
+            // Unity 5.5 on Windows (and probably all versions on all OSes) appear to use \n hardcoded when concatenating callstacks
+            // The above Split() operation will return the original string unaffected not do anything on Unity 5.5/Windows
+            // Therefore, if the split operation had no effect we try again with \n hardcoded
+            if (lines.Length == 1 && lines[0] == unityCallstack)
+                lines = System.Text.RegularExpressions.Regex.Split(unityCallstack, "\n");
+
             var stack = new List<LogStackFrame>();
             foreach(var line in lines)
             {


### PR DESCRIPTION
Unity 5.5 on Windows generates internal callstacks which are separated with \n, not \r\n. This is probably because Unity has internal string-concatenation code which happens to be hardcoded to use \n on all platforms. This change makes the Unity internal callstack splitting code first try with the OS version (either \n or \r\n depending on OS) and, if the split operation generated an identical string, tries again with \n hardcoded. This makes exception callstacks decode correctly on Unity 5.5/Windows.

I have tested this on Unity 5.5 on Windows. Haven't tried it on any other systems. I have tried to write it in such a way that it minimizes the risk of regression bugs on other systems.