### PR TITLE
Updated "ignore internal Unity method" logic for callstacks

### DIFF
--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -313,7 +313,11 @@ namespace UberLogger
 
             // Internal log-handling methods in Unity
             new IgnoredUnityMethod { DeclaringTypeName = "DebugLogHandler", MethodName = null, ShowHideMode = IgnoredUnityMethod.Mode.Hide },
-            new IgnoredUnityMethod { DeclaringTypeName = "Logger", MethodName = "Log", ShowHideMode = IgnoredUnityMethod.Mode.Hide },
+
+            // There are several entry points to Logger. These are primarily called by Unity's own code, but could also be called directly by 3rd party code.
+            // These are helpful to have on the callstack in case source code is not available (they help pinpoint the exact source code location that printed the message),
+            //   but remaining ignored methods can safely be hidden
+            new IgnoredUnityMethod { DeclaringTypeName = "Logger", MethodName = null, ShowHideMode = IgnoredUnityMethod.Mode.ShowIfFirstIgnoredMethod },
 
             // Many of the Debug.* entry points result in log messages being printed
             // These are helpful to have on the callstack in case source code is not available (they help pinpoint the exact source code location that printed the message),


### PR DESCRIPTION
I noticed that the callstacks did not look as clean as they could with Unity 5.5.

I have re-worked the ignore list system so that certain methods (or all methods within a given class) can be flagged as either: "show this method, but hide further ignored methods" and "hide this and further ignored methods".

The "show if first" mode makes it so that a callstack like this:
```
Application.CallLogCallback
DebugLogHandler.Internal_Log
DebugLogHandler.LogFormat
Logger.Log
Debug.LogWarning
<application callstack>
```
... will include the application callstack and the Debug.LogWarning call in the call stack, but ignore all the remaining internal methods. Including the Debug.LogWarning is helpful when figuring out exactly what line in a source file caused a given message to be printed, when you do not have access to the exact same source code.

The "hide" mode is the regular mode that you tag things with which you want to have hidden regardless.

I have also updated the list of methods to be accurate for Unity 5.5.

This, together with the changelist that makes doubleclick-on-message scan for the first open'able changelist, makes it so that both general Debug.Log and assertion failures result in having Debug.Log() / Assertion.IsNotNull() / ... at the top of the callstack, but double clicking on the message takes you to the line in your own source code which has the call to Debug.Log() / Assertion.IsNotNull() / ... .