### PR TITLE
Failed assertions should be classified as errors

### DIFF
--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -375,6 +375,7 @@ namespace UberLogger
                         switch(logType)
                         {
                             case UnityEngine.LogType.Error: severity = LogSeverity.Error; break;
+                            case UnityEngine.LogType.Assert: severity = LogSeverity.Error; break;
                             case UnityEngine.LogType.Exception: severity = LogSeverity.Error; break;
                             case UnityEngine.LogType.Warning: severity = LogSeverity.Warning; break;
                             default: severity = LogSeverity.Message; break;


### PR DESCRIPTION
When playing a scene, without a debugger attached, assertion failures arrive as LogType == Assert. With a debugger attached, they arrive as LogType == Exception. This change ensures that both types result in an Error in the log.

(Today, the Uber Console classifies things correctly when there is a debugger attached, but with no debugger it classifies failed assertions as regular messages.)