### PR TITLE
Convert directory separators to OS-native format

### DIFF
--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -656,7 +656,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
             var filename = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), osFileName);
             if (System.IO.File.Exists(filename))
             {
-                if (UnityEditorInternal.InternalEditorUtility.OpenFileAtLineExternal(osFileName, frame.LineNumber))
+                if (UnityEditorInternal.InternalEditorUtility.OpenFileAtLineExternal(filename, frame.LineNumber))
                     return true;
             }
         }

--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -648,20 +648,11 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
         ShowFrameSource = !ShowFrameSource;
     }
 
-    /// <summary>
-    /// Paths provided by Unity will contain forward slashes as directory separators on all OSes.
-    /// This method changes all forward slashes to OS-specific directory separators.
-    /// </summary>
-    string ConvertDirectorySeparatorsFromUnityToOS(string unityFileName)
-    {
-        return unityFileName.Replace('/', System.IO.Path.DirectorySeparatorChar);
-    }
-
     bool JumpToSource(LogStackFrame frame)
     {
         if (frame.FileName != null)
         {
-            var osFileName = ConvertDirectorySeparatorsFromUnityToOS(frame.FileName);
+            var osFileName = UberLogger.Logger.ConvertDirectorySeparatorsFromUnityToOS(frame.FileName);
             var filename = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), osFileName);
             if (System.IO.File.Exists(filename))
             {
@@ -791,7 +782,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
             return "";
         }
 
-        var osFileName = ConvertDirectorySeparatorsFromUnityToOS(frame.FileName);
+        var osFileName = UberLogger.Logger.ConvertDirectorySeparatorsFromUnityToOS(frame.FileName);
         var filename = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), osFileName);
         if (!System.IO.File.Exists(filename))
         {

--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -648,14 +648,24 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
         ShowFrameSource = !ShowFrameSource;
     }
 
+    /// <summary>
+    /// Paths provided by Unity will contain forward slashes as directory separators on all OSes.
+    /// This method changes all forward slashes to OS-specific directory separators.
+    /// </summary>
+    string ConvertDirectorySeparatorsFromUnityToOS(string unityFileName)
+    {
+        return unityFileName.Replace('/', System.IO.Path.DirectorySeparatorChar);
+    }
+
     bool JumpToSource(LogStackFrame frame)
     {
         if (frame.FileName != null)
         {
-            var filename = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), frame.FileName);
+            var osFileName = ConvertDirectorySeparatorsFromUnityToOS(frame.FileName);
+            var filename = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), osFileName);
             if (System.IO.File.Exists(filename))
             {
-                if (UnityEditorInternal.InternalEditorUtility.OpenFileAtLineExternal(frame.FileName, frame.LineNumber))
+                if (UnityEditorInternal.InternalEditorUtility.OpenFileAtLineExternal(osFileName, frame.LineNumber))
                     return true;
             }
         }
@@ -780,7 +790,9 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
         {
             return "";
         }
-        var filename = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), frame.FileName);
+
+        var osFileName = ConvertDirectorySeparatorsFromUnityToOS(frame.FileName);
+        var filename = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), osFileName);
         if (!System.IO.File.Exists(filename))
         {
             return "";

--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -196,7 +196,12 @@ namespace UberLogger
         //  System.Environment.NewLine when you want to split multi-line strings which are emitted
         //  by Unity's internal APIs.
         public static string UnityInternalNewLine = "\n";
-	
+
+        // Unity uses forward-slashes as directory separators, regardless of OS.
+        // Convert from this separator to System.IO.Path.DirectorySeparatorChar before passing any Unity-originated
+        //  paths to APIs which expect OS-native paths.
+        public static char UnityInternalDirectorySeparator = '/';
+
         static List<ILogger> Loggers = new List<ILogger>();
         static LinkedList<LogInfo> RecentMessages = new LinkedList<LogInfo>();
         static long StartTick;
@@ -251,6 +256,15 @@ namespace UberLogger
                     Loggers.Add(logger);
                 }
             }
+        }
+
+        /// <summary>
+        /// Paths provided by Unity will contain forward slashes as directory separators on all OSes.
+        /// This method changes all forward slashes to OS-specific directory separators.
+        /// </summary>
+        static public string ConvertDirectorySeparatorsFromUnityToOS(string unityFileName)
+        {
+            return unityFileName.Replace(UnityInternalDirectorySeparator, System.IO.Path.DirectorySeparatorChar);
         }
 
         /// <summary>


### PR DESCRIPTION
This should resolve any problems with opening paths on the form `Assets/blah/...` under Windows. Should fix #18. Should make #2 obsolete.