### PR TITLE
Structured file logger

### DIFF
--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -542,7 +542,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
             for(int c1=0; c1<log.Callstack.Count; c1++)
             {
                 var frame = log.Callstack[c1];
-                var methodName = frame.GetFormattedMethodName();
+                var methodName = frame.GetFormattedMethodNameWithFileName();
                 if(!String.IsNullOrEmpty(methodName))
                 {
                     var content = new GUIContent(methodName);

--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -80,6 +80,19 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
 
     }
 
+    /// <summary>
+    /// Converts the entire message log to a multiline string
+    /// </summary>
+    public string ExtractLogListToString()
+    {
+        string result = "";
+        foreach (CountedLog log in RenderLogs)
+        {
+            UberLogger.LogInfo logInfo = log.Log;
+            result += logInfo.GetRelativeTimeStampAsString() + ": " + logInfo.Severity + ": " + logInfo.Message + "\n";
+        }
+        return result;
+    }
 
     Vector2 DrawPos;
     public void OnGUI()
@@ -302,7 +315,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
         showMessage = showMessage.Replace(UberLogger.Logger.UnityInternalNewLine, " ");
         if(showTimes)
         {
-            showMessage = log.GetTimeStampAsString() + ": " + showMessage; 
+            showMessage = log.GetRelativeTimeStampAsString() + ": " + showMessage; 
         }
 
         var content = new GUIContent(showMessage, GetIconForLog(log));

--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -394,7 +394,7 @@ namespace UberLogger
                 {
                     IgnoredUnityMethod.Mode showHideMode = ShowOrHideMethod(method);
 
-                    bool setOriginatingSourceLocation = (showHideMode == IgnoredUnityMethod.Mode.Show && originatingSourceLocation == null);
+                    bool setOriginatingSourceLocation = (showHideMode == IgnoredUnityMethod.Mode.Show);
 
                     if (showHideMode == IgnoredUnityMethod.Mode.ShowIfFirstIgnoredMethod)
                     {

--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -139,12 +139,19 @@ namespace UberLogger
         public LogSeverity Severity;
         public string Message;
         public List<LogStackFrame> Callstack;
-        public double TimeStamp;
-        string TimeStampAsString;
+        public double RelativeTimeStamp;
+        string RelativeTimeStampAsString;
+        public DateTime AbsoluteTimeStamp;
+        string AbsoluteTimeStampAsString;
 
-        public string GetTimeStampAsString()
+        public string GetRelativeTimeStampAsString()
         {
-            return TimeStampAsString;
+            return RelativeTimeStampAsString;
+        }
+
+        public string GetAbsoluteTimeStampAsString()
+        {
+            return AbsoluteTimeStampAsString;
         }
 
         public LogInfo(UnityEngine.Object source, string channel, LogSeverity severity, List<LogStackFrame> callstack, object message, params object[] par)
@@ -175,8 +182,10 @@ namespace UberLogger
             }
 
             Callstack = callstack;
-            TimeStamp = Logger.GetTime();
-            TimeStampAsString = String.Format("{0:0.0000}", TimeStamp);
+            RelativeTimeStamp = Logger.GetRelativeTime();
+            AbsoluteTimeStamp = DateTime.UtcNow;
+            RelativeTimeStampAsString = String.Format("{0:0.0000}", RelativeTimeStamp);
+            AbsoluteTimeStampAsString = AbsoluteTimeStamp.ToString("yyyy-MM-dd HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture);
         }
     }
 
@@ -224,7 +233,7 @@ namespace UberLogger
             UnityLogInternal(logString, stackTrace, logType);
         }
     
-        static public double GetTime()
+        static public double GetRelativeTime()
         {
             long ticks = DateTime.Now.Ticks;
             return TimeSpan.FromTicks(ticks - StartTick).TotalSeconds;

--- a/UberLoggerAppWindow.cs
+++ b/UberLoggerAppWindow.cs
@@ -345,7 +345,7 @@ public class UberLoggerAppWindow : MonoBehaviour, UberLogger.ILogger
             for(int c1=0; c1<log.Callstack.Count; c1++)
             {
                 var frame = log.Callstack[c1];
-                var methodName = frame.GetFormattedMethodName();
+                var methodName = frame.GetFormattedMethodNameWithFileName();
                 if(!String.IsNullOrEmpty(methodName))
                 {
                     if(c1==SelectedCallstackFrame)

--- a/UberLoggerAppWindow.cs
+++ b/UberLoggerAppWindow.cs
@@ -293,7 +293,7 @@ public class UberLoggerAppWindow : MonoBehaviour, UberLogger.ILogger
                     showMessage = showMessage.Replace(UberLogger.Logger.UnityInternalNewLine, " ");
                     if(ShowTimes)
                     {
-                        showMessage = log.GetTimeStampAsString() + ": " + showMessage; 
+                        showMessage = log.GetRelativeTimeStampAsString() + ": " + showMessage; 
                     }
 
                     var content = new GUIContent(showMessage, GetIconForLog(log));

--- a/UberLoggerFile.cs
+++ b/UberLoggerFile.cs
@@ -33,7 +33,7 @@ public class UberLoggerFile : UberLogger.ILogger
             {
                 foreach(var frame in logInfo.Callstack)
                 {
-                    LogFileWriter.WriteLine(frame.GetFormattedMethodName());
+                    LogFileWriter.WriteLine(frame.GetFormattedMethodNameWithFileName());
                 }
                 LogFileWriter.WriteLine();
             }

--- a/UberLoggerLogToFile.cs
+++ b/UberLoggerLogToFile.cs
@@ -20,11 +20,13 @@ public class UberLoggerLogToFile : MonoBehaviour
             UberLogger.Logger.AddLogger(uberLoggerFile);
         }
 
-        // Create a logger that writes to dataPath
+#if !UNITY_EDITOR
+        // If running a separately-built executable, also create a logger that writes to dataPath
         // The file location is easy for people to find, but sometimes the location is read-only
         {
             UberLoggerStructuredFile uberLoggerFile = new UberLoggerStructuredFile(System.IO.Path.Combine(Application.dataPath, OutputFile), Indentation);
             UberLogger.Logger.AddLogger(uberLoggerFile);
         }
+#endif
     }
 }

--- a/UberLoggerLogToFile.cs
+++ b/UberLoggerLogToFile.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+using UberLogger;
+
+/// <summary>
+/// Place this component in the scene to log all console output to a file with a structured format
+/// </summary>
+public class UberLoggerLogToFile : MonoBehaviour
+{
+    public string OutputFile = "output_log_structured.txt";
+
+    public UberLoggerStructuredFile.IndentationSettings Indentation;
+
+    private void Start()
+    {
+        DontDestroyOnLoad(gameObject);
+        UberLoggerStructuredFile uberLoggerFile = new UberLoggerStructuredFile(OutputFile, Indentation);
+        UberLogger.Logger.AddLogger(uberLoggerFile);
+    }
+}

--- a/UberLoggerLogToFile.cs
+++ b/UberLoggerLogToFile.cs
@@ -13,7 +13,18 @@ public class UberLoggerLogToFile : MonoBehaviour
     private void Start()
     {
         DontDestroyOnLoad(gameObject);
-        UberLoggerStructuredFile uberLoggerFile = new UberLoggerStructuredFile(OutputFile, Indentation);
-        UberLogger.Logger.AddLogger(uberLoggerFile);
+
+        // Create a logger that writes to persistentDataPath
+        {
+            UberLoggerStructuredFile uberLoggerFile = new UberLoggerStructuredFile(System.IO.Path.Combine(Application.persistentDataPath, OutputFile), Indentation);
+            UberLogger.Logger.AddLogger(uberLoggerFile);
+        }
+
+        // Create a logger that writes to dataPath
+        // The file location is easy for people to find, but sometimes the location is read-only
+        {
+            UberLoggerStructuredFile uberLoggerFile = new UberLoggerStructuredFile(System.IO.Path.Combine(Application.dataPath, OutputFile), Indentation);
+            UberLogger.Logger.AddLogger(uberLoggerFile);
+        }
     }
 }

--- a/UberLoggerLogToFile.cs
+++ b/UberLoggerLogToFile.cs
@@ -9,14 +9,16 @@ public class UberLoggerLogToFile : MonoBehaviour
     public string OutputFile = "output_log_structured.txt";
 
     public UberLoggerStructuredFile.IndentationSettings Indentation;
+    public UberLoggerStructuredFile.IncludeCallstackMode IncludeCallStacks;
+    public UberLoggerStructuredFile.ExistingFileMode ExistingFile;
 
-    private void Start()
+    private void Awake()
     {
         DontDestroyOnLoad(gameObject);
 
         // Create a logger that writes to persistentDataPath
         {
-            UberLoggerStructuredFile uberLoggerFile = new UberLoggerStructuredFile(System.IO.Path.Combine(Application.persistentDataPath, OutputFile), Indentation);
+            UberLoggerStructuredFile uberLoggerFile = new UberLoggerStructuredFile(System.IO.Path.Combine(Application.persistentDataPath, OutputFile), Indentation, IncludeCallStacks, ExistingFile);
             UberLogger.Logger.AddLogger(uberLoggerFile);
         }
 
@@ -24,7 +26,7 @@ public class UberLoggerLogToFile : MonoBehaviour
         // If running a separately-built executable, also create a logger that writes to dataPath
         // The file location is easy for people to find, but sometimes the location is read-only
         {
-            UberLoggerStructuredFile uberLoggerFile = new UberLoggerStructuredFile(System.IO.Path.Combine(Application.dataPath, OutputFile), Indentation);
+            UberLoggerStructuredFile uberLoggerFile = new UberLoggerStructuredFile(System.IO.Path.Combine(Application.dataPath, OutputFile), Indentation, IncludeCallStacks, ExistingFile);
             UberLogger.Logger.AddLogger(uberLoggerFile);
         }
 #endif

--- a/UberLoggerLogToFile.cs.meta
+++ b/UberLoggerLogToFile.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1b33767a885a7004e909ebc0fc1ee560
+timeCreated: 1491481727
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UberLoggerLogToFile.prefab
+++ b/UberLoggerLogToFile.prefab
@@ -1,0 +1,54 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1513173478985856}
+  m_IsPrefabParent: 1
+--- !u!1 &1513173478985856
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4007639379866844}
+  - component: {fileID: 114645551039098692}
+  m_Layer: 0
+  m_Name: UberLoggerLogToFile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4007639379866844
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1513173478985856}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 37.499863, y: 0.006358128, z: 144.13428}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114645551039098692
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1513173478985856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b33767a885a7004e909ebc0fc1ee560, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  outputFile: output_log_structured.txt

--- a/UberLoggerLogToFile.prefab
+++ b/UberLoggerLogToFile.prefab
@@ -51,4 +51,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1b33767a885a7004e909ebc0fc1ee560, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  outputFile: output_log_structured.txt
+  OutputFile: output_log_structured.txt
+  Indentation:
+    TabSize: 8
+    TimeMinTabs: 4
+    MessageMinTabs: 16
+    ChannelMinTabs: 1
+    SeverityMinTabs: 2
+    FileNameMinTabs: 16
+    MethodMinTabs: 8
+  IncludeCallStacks: 1
+  ExistingFile: 1

--- a/UberLoggerLogToFile.prefab.meta
+++ b/UberLoggerLogToFile.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52fd72d778e8ad941b43d57553adc073
+timeCreated: 1491484476
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UberLoggerStructuredFile.cs
+++ b/UberLoggerStructuredFile.cs
@@ -41,15 +41,15 @@ public class UberLoggerStructuredFile : UberLogger.ILogger
 
     /// <summary>
     /// Constructor. Make sure to add it to UberLogger via Logger.AddLogger();
-    /// <param name="filename">Output file name. Relative to Application.persistentDataPath.</param>
+    /// <param name="fileLogPath">Output file name (absolute path)</param>
     /// <param name="indentationSettings">Provide tab settings to get an output that uses tabs to align fields above each other visually. Pass null to always have 1 tab between columns.</param>
     /// <param name="includeCallStacks">When to show callstacks in log; never, only for warnings/errors, or always</param>
     /// </summary>
-    public UberLoggerStructuredFile(string filename, IndentationSettings indentation, IncludeCallstackMode includeCallStacks = IncludeCallstackMode.WarningsAndErrorsOnly)
+    public UberLoggerStructuredFile(string fileLogPath, IndentationSettings indentation, IncludeCallstackMode includeCallStacks = IncludeCallstackMode.WarningsAndErrorsOnly)
     {
         IncludeCallStacks = includeCallStacks;
         Indentation = indentation;
-        var fileLogPath = System.IO.Path.Combine(Application.persistentDataPath, filename);
+
         Debug.Log("Initialising file logging to " + fileLogPath);
         LogFileWriter = new StreamWriter(fileLogPath, false);
         LogFileWriter.AutoFlush = true;
@@ -107,9 +107,9 @@ public class UberLoggerStructuredFile : UberLogger.ILogger
             {
                 LogStackFrame stackFrame = logInfo.OriginatingSourceLocation;
 
-                formattedLine += PadString(stackFrame.FileName + "(" + stackFrame.LineNumber + ")", Indentation.FileNameMinTabs);
+                formattedLine += PadString(stackFrame.GetFormattedFileName(), Indentation.FileNameMinTabs);
 
-                formattedLine += PadString(stackFrame.DeclaringType + "." + stackFrame.MethodName + "()", Indentation.MethodMinTabs);
+                formattedLine += PadString(stackFrame.GetFormattedMethodName(), Indentation.MethodMinTabs);
             }
             else
                 formattedLine += PadString("<No callstack>", Indentation.FileNameMinTabs) + PadString("<Unknown method>", Indentation.MethodMinTabs);
@@ -137,8 +137,8 @@ public class UberLoggerStructuredFile : UberLogger.ILogger
                         + PadString("", Indentation.MessageMinTabs)
                         + PadString(logInfo.Channel, Indentation.ChannelMinTabs)
                         + PadString("Callstack", Indentation.SeverityMinTabs)
-                        + PadString(frame.FileName + "(" + frame.LineNumber + ")", Indentation.FileNameMinTabs)
-                        + PadString(frame.DeclaringType + "." + frame.MethodName + "()", Indentation.MethodMinTabs);
+                        + PadString(frame.GetFormattedFileName(), Indentation.FileNameMinTabs)
+                        + PadString(frame.GetFormattedMethodName(), Indentation.MethodMinTabs);
 
                     LogFileWriter.WriteLine(line);
                 }

--- a/UberLoggerStructuredFile.cs
+++ b/UberLoggerStructuredFile.cs
@@ -4,12 +4,15 @@ using UberLogger;
 using UnityEngine;
 
 /// <summary>
-/// File logger backend, which writes log files with a structured format:
-/// [Timestamp, in UTC time coordinates] <message/warning/exception> <file> <method> <message>
-/// Fields will be visually aligned via tabs. If you 
+/// <para>File logger backend, which writes log files with a structured format:</para>
+/// <para>[Timestamp, in UTC time coordinates] message/warning/exception file method message</para>
+/// <para>Fields will be visually aligned via tabs.</para>
 /// </summary>
 public class UberLoggerStructuredFile : UberLogger.ILogger
 {
+    /// <summary>
+    /// Which types of log messages shall include full callstacks
+    /// </summary>
     public enum IncludeCallstackMode
     {
         Never,
@@ -17,9 +20,18 @@ public class UberLoggerStructuredFile : UberLogger.ILogger
         Always
     }
 
+    /// <summary>
+    /// What to do if the the log file already exists when UberLoggerStructuredFile starts
+    /// </summary>
     public enum ExistingFileMode
     {
+        /// <summary>
+        /// Replace the existing log file with the new log file
+        /// </summary>
         Overwrite,
+        /// <summary>
+        /// Add a suffix to the log file name, which makes the new file name unique
+        /// </summary>
         DoNotOverwrite
     };
 
@@ -46,12 +58,12 @@ public class UberLoggerStructuredFile : UberLogger.ILogger
     public IndentationSettings Indentation;
 
     /// <summary>
-    /// Constructor. Make sure to add it to UberLogger via Logger.AddLogger();
+    /// Creates a logger which writes to disk with a structured format. Make sure to add the created object to UberLogger via Logger.AddLogger() as well.
+    /// </summary>
     /// <param name="fileLogPath">Output file name (absolute path)</param>
     /// <param name="indentationSettings">Provide tab settings to get an output that uses tabs to align fields above each other visually. Pass null to always have 1 tab between columns.</param>
     /// <param name="includeCallStacks">When to show callstacks in log; never, only for warnings/errors, or always</param>
     /// <param name="existingFileMode">If set to Overwrite, overwrite existing log file; if set to DoNotOverwrite, add suffixes (.1 .2 etc) until an unused file name is found</param>
-    /// </summary>
     public UberLoggerStructuredFile(string fileLogPath, IndentationSettings indentation, IncludeCallstackMode includeCallStacks = IncludeCallstackMode.WarningsAndErrorsOnly, ExistingFileMode existingFileHandling = ExistingFileMode.Overwrite)
     {
         IncludeCallStacks = includeCallStacks;

--- a/UberLoggerStructuredFile.cs
+++ b/UberLoggerStructuredFile.cs
@@ -1,0 +1,136 @@
+﻿using UberLogger;
+using System.IO;
+using UnityEngine;
+
+/// <summary>
+/// File logger backend, which writes log files with a structured format:
+/// [Timestamp, in UTC time coordinates] <message/warning/exception> <file> <method> <message>
+/// Fields will be visually aligned via tabs. If you 
+/// </summary>
+public class UberLoggerStructuredFile : UberLogger.ILogger
+{
+    public enum IncludeCallstackMode
+    {
+        Never,
+        WarningsAndErrorsOnly,
+        Always
+    }
+
+
+    private StreamWriter LogFileWriter;
+    private IncludeCallstackMode IncludeCallStacks;
+    private bool VisualAlign;
+
+    /// <summary>
+    /// Assumed tab size when VisualAlign is active
+    /// </summary>
+    private const int TabSize = 8;
+
+    // With (in tabs) of each column when VisualAlign is active
+    private const int PadTimeTabs = 4;
+    private const int PadSeverityTabs = 2;
+    private const int PadFileNameTabs = 16;
+    private const int PadMethodTabs = 8;
+
+    /// <summary>
+    /// Constructor. Make sure to add it to UberLogger via Logger.AddLogger();
+    /// <param name="filename">Output file name. Relative to Application.persistentDataPath.</param>
+    /// <param name="visualAlign">Set this to get an output that uses tabs to align fields above each other visually. Set to false to always have 1 tab between columns.</param>
+    /// <param name="includeCallStacks">When to show callstacks in log; never, only for warnings/errors, or always</param>
+    /// </summary>
+    public UberLoggerStructuredFile(string filename, bool visualAlign = true, IncludeCallstackMode includeCallStacks = IncludeCallstackMode.WarningsAndErrorsOnly)
+    {
+        IncludeCallStacks = includeCallStacks;
+        VisualAlign = visualAlign;
+        var fileLogPath = System.IO.Path.Combine(Application.persistentDataPath, filename);
+        Debug.Log("Initialising file logging to " + fileLogPath);
+        LogFileWriter = new StreamWriter(fileLogPath, false);
+        LogFileWriter.AutoFlush = true;
+    }
+
+    /// <summary>
+    /// Pad input string with at least one \t, but -- if the string is too short, and VisualAlign is requested, extra tabs
+    /// </summary>
+    private string PadString(string originalString, int minimumOutputTabs)
+    {
+        if (VisualAlign)
+        {
+            string str = originalString + "\t";
+            int tabCount = ((str.Length + (TabSize - 1)) / TabSize);
+            for (int i = tabCount; i < minimumOutputTabs; i++)
+                str += "\t";
+
+            return str;
+        }
+        else
+            return originalString + "\t";
+    }
+
+    /// <summary>
+    ///  Write one log entry to output file
+    /// </summary>
+    public void Log(LogInfo logInfo)
+    {
+        lock (this)
+        {
+            string formattedLine = "";
+
+            // Timestamp
+
+            string absoluteTimeStamp = logInfo.GetAbsoluteTimeStampAsString();
+            formattedLine += PadString("[" + absoluteTimeStamp + "]", PadTimeTabs);
+
+            // Severity
+
+            formattedLine += PadString(logInfo.Severity + ":", PadSeverityTabs);
+
+            // Source location + class/method
+
+            if (logInfo.OriginatingSourceLocation != null)
+            {
+                LogStackFrame stackFrame = logInfo.OriginatingSourceLocation;
+
+                formattedLine += PadString(stackFrame.FileName + "(" + stackFrame.LineNumber + "):", PadFileNameTabs);
+
+                formattedLine += PadString(stackFrame.DeclaringType + "." + stackFrame.MethodName + "():", PadMethodTabs);
+            }
+            else
+                formattedLine += PadString("<No callstack>:", PadFileNameTabs) + PadString("<Unknown method>:", PadMethodTabs);
+
+            // Message
+
+            string message = logInfo.Message;
+            message = message.Replace(UberLogger.Logger.UnityInternalNewLine, " "); // Ensure message goes on a single line
+
+            formattedLine += message;
+
+            LogFileWriter.WriteLine(formattedLine);
+
+
+            // Write callstack, if necessary
+
+            bool includeCallStack = (logInfo.Callstack.Count > 0);
+
+            if (IncludeCallStacks == IncludeCallstackMode.Never)
+                includeCallStack = false;
+
+            if (IncludeCallStacks == IncludeCallstackMode.WarningsAndErrorsOnly
+                && logInfo.Severity == LogSeverity.Message)
+                includeCallStack = false;
+
+            if (includeCallStack)
+            {
+                foreach (var frame in logInfo.Callstack)
+                {
+                    string line = PadString("", PadTimeTabs)
+                        + PadString("Callstack:", PadSeverityTabs)
+                        + PadString(frame.FileName + "(" + frame.LineNumber + "):", PadFileNameTabs)
+                        + PadString(frame.DeclaringType + "." + frame.MethodName + "()", PadMethodTabs);
+
+                    LogFileWriter.WriteLine(line);
+                }
+                LogFileWriter.WriteLine();
+            }
+        }
+    }
+}

--- a/UberLoggerStructuredFile.cs.meta
+++ b/UberLoggerStructuredFile.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1009491a2e631ea4098d2547167b72d3
+timeCreated: 1491482514
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This provides a much more detailed log file than either Unity's own output log, or UberLoggerFile does. The intention is to include much more information in the logs, thereby making it easier to diagnose errors which occur in deployed builds.

Main features:
* UTC timestamps for each log message (useful when correlating logs from multiple machines in the same MP match)
* Channel information present in logs
* One log message per line, except when callstacks are included
* Ability to have full callstacks in logs - either for all messages, or only for warnings/errors