### PR TITLE
Support for Unity 2017.1+

### DIFF
--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -59,8 +59,9 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
         // And, due to Unity serialisation stuff, necessary to do to it here.
         UberLogger.Logger.AddLogger(EditorLogger);
         EditorLogger.AddWindow(this);
-        
-#if UNITY_5
+
+// _OR_NEWER only became available from 5.3
+#if UNITY_5 || UNITY_5_3_OR_NEWER
         titleContent.text = "Uber Console";
 #else
         title = "Uber Console";

--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -211,7 +211,8 @@ namespace UberLogger
         static Logger()
         {
             // Register with Unity's logging system
-#if UNITY_5
+// _OR_NEWER only available from 5.3+
+#if UNITY_5 || UNITY_5_3_OR_NEWER
             Application.logMessageReceivedThreaded += UnityLogHandler;
 #else
             Application.RegisterLogCallback(UnityLogHandler);


### PR DESCRIPTION
2017.1 does not define UNITY_5 so we need to use UNITY_5_3_OR_NEWER as well (sadly there is no UNITY_5_0_OR_NEWER)