### PR TITLE
Preparations for structured-file support & Stackdriver support

### DIFF
--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -542,7 +542,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
             for(int c1=0; c1<log.Callstack.Count; c1++)
             {
                 var frame = log.Callstack[c1];
-                var methodName = frame.GetFormattedMethodName();
+                var methodName = frame.GetFormattedMethodNameWithFileName();
                 if(!String.IsNullOrEmpty(methodName))
                 {
                     var content = new GUIContent(methodName);

--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -80,6 +80,19 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
 
     }
 
+    /// <summary>
+    /// Converts the entire message log to a multiline string
+    /// </summary>
+    public string ExtractLogListToString()
+    {
+        string result = "";
+        foreach (CountedLog log in RenderLogs)
+        {
+            UberLogger.LogInfo logInfo = log.Log;
+            result += logInfo.GetRelativeTimeStampAsString() + ": " + logInfo.Severity + ": " + logInfo.Message + "\n";
+        }
+        return result;
+    }
 
     Vector2 DrawPos;
     public void OnGUI()
@@ -302,7 +315,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
         showMessage = showMessage.Replace(UberLogger.Logger.UnityInternalNewLine, " ");
         if(showTimes)
         {
-            showMessage = log.GetTimeStampAsString() + ": " + showMessage; 
+            showMessage = log.GetRelativeTimeStampAsString() + ": " + showMessage; 
         }
 
         var content = new GUIContent(showMessage, GetIconForLog(log));

--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -428,7 +428,7 @@ namespace UberLogger
                 {
                     IgnoredUnityMethod.Mode showHideMode = ShowOrHideMethod(method);
 
-                    bool setOriginatingSourceLocation = (showHideMode == IgnoredUnityMethod.Mode.Show && originatingSourceLocation == null);
+                    bool setOriginatingSourceLocation = (showHideMode == IgnoredUnityMethod.Mode.Show);
 
                     if (showHideMode == IgnoredUnityMethod.Mode.ShowIfFirstIgnoredMethod)
                     {

--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -139,12 +139,19 @@ namespace UberLogger
         public LogSeverity Severity;
         public string Message;
         public List<LogStackFrame> Callstack;
-        public double TimeStamp;
-        string TimeStampAsString;
+        public double RelativeTimeStamp;
+        string RelativeTimeStampAsString;
+        public DateTime AbsoluteTimeStamp;
+        string AbsoluteTimeStampAsString;
 
-        public string GetTimeStampAsString()
+        public string GetRelativeTimeStampAsString()
         {
-            return TimeStampAsString;
+            return RelativeTimeStampAsString;
+        }
+
+        public string GetAbsoluteTimeStampAsString()
+        {
+            return AbsoluteTimeStampAsString;
         }
 
         public LogInfo(UnityEngine.Object source, string channel, LogSeverity severity, List<LogStackFrame> callstack, object message, params object[] par)
@@ -175,8 +182,10 @@ namespace UberLogger
             }
 
             Callstack = callstack;
-            TimeStamp = Logger.GetTime();
-            TimeStampAsString = String.Format("{0:0.0000}", TimeStamp);
+            RelativeTimeStamp = Logger.GetRelativeTime();
+            AbsoluteTimeStamp = DateTime.UtcNow;
+            RelativeTimeStampAsString = String.Format("{0:0.0000}", RelativeTimeStamp);
+            AbsoluteTimeStampAsString = AbsoluteTimeStamp.ToString("yyyy-MM-dd HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture);
         }
     }
 
@@ -224,7 +233,7 @@ namespace UberLogger
             UnityLogInternal(logString, stackTrace, logType);
         }
     
-        static public double GetTime()
+        static public double GetRelativeTime()
         {
             long ticks = DateTime.Now.Ticks;
             return TimeSpan.FromTicks(ticks - StartTick).TotalSeconds;

--- a/UberLoggerAppWindow.cs
+++ b/UberLoggerAppWindow.cs
@@ -345,7 +345,7 @@ public class UberLoggerAppWindow : MonoBehaviour, UberLogger.ILogger
             for(int c1=0; c1<log.Callstack.Count; c1++)
             {
                 var frame = log.Callstack[c1];
-                var methodName = frame.GetFormattedMethodName();
+                var methodName = frame.GetFormattedMethodNameWithFileName();
                 if(!String.IsNullOrEmpty(methodName))
                 {
                     if(c1==SelectedCallstackFrame)

--- a/UberLoggerAppWindow.cs
+++ b/UberLoggerAppWindow.cs
@@ -293,7 +293,7 @@ public class UberLoggerAppWindow : MonoBehaviour, UberLogger.ILogger
                     showMessage = showMessage.Replace(UberLogger.Logger.UnityInternalNewLine, " ");
                     if(ShowTimes)
                     {
-                        showMessage = log.GetTimeStampAsString() + ": " + showMessage; 
+                        showMessage = log.GetRelativeTimeStampAsString() + ": " + showMessage; 
                     }
 
                     var content = new GUIContent(showMessage, GetIconForLog(log));

--- a/UberLoggerFile.cs
+++ b/UberLoggerFile.cs
@@ -33,7 +33,7 @@ public class UberLoggerFile : UberLogger.ILogger
             {
                 foreach(var frame in logInfo.Callstack)
                 {
-                    LogFileWriter.WriteLine(frame.GetFormattedMethodName());
+                    LogFileWriter.WriteLine(frame.GetFormattedMethodNameWithFileName());
                 }
                 LogFileWriter.WriteLine();
             }


### PR DESCRIPTION
In splitting things up so that [StructuredFile](http://www.github.com/falldamagestudio/UberLogger-StructuredFile) and [Stackdriver](https://github.com/falldamagestudio/UberLogger-Stackdriver) are their own projects, I've needed to do a couple of cleanups in the base UberLogger code.

* LogInfo needs to carry absolute timestamps for log messages
* LogInfo needs to decide, as a single line, which the most likely "originating source location" is based on what is in the callstack
* LogInfo should make it possible for external code to get callstacks in standard C# format -- that is "Classname.MethodName (at file.cs:14)"'

This is a set of changes which accomplishes just that.