### PR TITLE
Filter hook for processing log messages

### DIFF
--- a/UberLogger.cs
+++ b/UberLogger.cs
@@ -37,7 +37,20 @@ namespace UberLogger
         /// </summary>
         void Log(LogInfo logInfo);
     }
-    
+
+    /// <summary>
+    /// Interface for implementing new log message filter methods.
+    /// Filters will be applied to log messages before they are forwarded to any loggers or Unity itself.
+    /// </summary>
+    public interface IFilter
+    {
+        /// <summary>
+        /// Apply filter to log message.
+        /// Should return true if the message is to be kept, and false if the message is to be silenced.
+        /// </summary>
+        bool ApplyFilter(string channel, UnityEngine.Object source, LogSeverity severity, object message, params object[] par);
+    }
+
     //Information about a particular frame of a callstack
     [System.Serializable]
     public class LogStackFrame
@@ -207,7 +220,8 @@ namespace UberLogger
         static long StartTick;
         static bool AlreadyLogging = false;
         static Regex UnityMessageRegex;
-
+        static List<IFilter> Filters = new List<IFilter>();
+        
         static Logger()
         {
             // Register with Unity's logging system
@@ -256,6 +270,17 @@ namespace UberLogger
                 {
                     Loggers.Add(logger);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Registers a new filter mechanism, which will be able to silence any future log messages
+        /// </summary>
+        static public void AddFilter(IFilter filter)
+        {
+            lock (Loggers)
+            {
+                Filters.Add(filter);
             }
         }
 
@@ -527,6 +552,13 @@ namespace UberLogger
                     try
                     {
                         AlreadyLogging = true;
+
+                        foreach (IFilter filter in Filters)
+                        {
+                            if (!filter.ApplyFilter(channel, source, severity, message, par))
+                                return;
+                        }
+						
                         var callstack = new List<LogStackFrame>();
                         var unityOnly = GetCallstack(ref callstack);
                         if(unityOnly)


### PR DESCRIPTION
This is filtering interface support for [UberLogger-FilterChannels](https://github.com/falldamagestudio/UberLogger-FilterChannels). I think it makes sense for the general UberLogger project as well.

UberLogger-FilterChannels enables us to have a lot of `UberLogger.LogChannel(...)` calls in our codebase, with most channels being muted. This strategy helps keep log files fairly clean and readable for the bulk of people on the team. Individual developers that want more diagnostic information from a specific subsystem can then unmute that specific channel by changing a single line in a config file and re-run the game.

My main concern with this muting approach is that all the log calls and computation of arguments will be present in release builds, with no mechanism for making those calls disappear from the executable (not even in a "final final" build configuration). A compile-time muting mechanism will probably involve the build system and will be difficult to package in a plug-and-play format.