### PR TITLE
Support for Unity 2017.3

### DIFF
--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -812,7 +812,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
         GUI.color = oldColor;
         EditorGUIUtility.AddCursorRect(CursorChangeRect,MouseCursor.ResizeVertical);
          
-        if( Event.current.type == EventType.mouseDown && CursorChangeRect.Contains(Event.current.mousePosition))
+        if( Event.current.type == EventType.MouseDown && CursorChangeRect.Contains(Event.current.mousePosition))
         {
             Resize = true;
         }

--- a/UberLoggerAppWindow.cs
+++ b/UberLoggerAppWindow.cs
@@ -437,7 +437,7 @@ public class UberLoggerAppWindow : MonoBehaviour, UberLogger.ILogger
         GUI.DrawTexture(resizerRect, Texture2D.whiteTexture);
         GUI.color = oldColor;
 
-        if( Event.current.type == EventType.mouseDown && resizerRect.Contains(Event.current.mousePosition))
+        if( Event.current.type == EventType.MouseDown && resizerRect.Contains(Event.current.mousePosition))
         {
             Resizing = true;
         }


### PR DESCRIPTION
EventType.mouseDown is already deprecated in Unity 4.x and Unity forcibly deprecate this API in Unity 2017.3.

See https://docs.unity3d.com/ScriptReference/EventType.html
