### PR TITLE
Add ability to toggle showing/hiding channel in log output

### DIFF
--- a/Editor/UberLoggerEditorWindow.cs
+++ b/Editor/UberLoggerEditorWindow.cs
@@ -267,6 +267,13 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
             ShowTimes = showTimes;
         }
         DrawPos.x += elementSize.x;
+        var showChannels = ToggleClamped(ShowChannels, "Channels", EditorStyles.toolbarButton, out elementSize);
+        if (showChannels != ShowChannels)
+        {
+            MakeDirty = true;
+            ShowChannels = showChannels;
+        }
+        DrawPos.x += elementSize.x;
         var collapse = ToggleClamped(Collapse, "Collapse", EditorStyles.toolbarButton, out elementSize);
         if(collapse!=Collapse)
         {
@@ -365,15 +372,19 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
     /// <summary>
     /// Converts a given log element into a piece of gui content to be displayed
     /// </summary>
-    GUIContent GetLogLineGUIContent(UberLogger.LogInfo log, bool showTimes)
+    GUIContent GetLogLineGUIContent(UberLogger.LogInfo log, bool showTimes, bool showChannels)
     {
         var showMessage = log.Message;
         //Make all messages single line
         showMessage = showMessage.Replace(UberLogger.Logger.UnityInternalNewLine, " ");
-        if(showTimes)
-        {
-            showMessage = log.GetRelativeTimeStampAsString() + ": " + showMessage; 
-        }
+
+        showMessage = string.Format("{0}{1}{2}{3}{4}",
+                showChannels ? "[" + log.Channel + "]" : "",
+                showTimes && showChannels ? " " : "",
+                showTimes ? log.GetRelativeTimeStampAsString() : "",
+                showChannels || showTimes ? " : " : "",
+                showMessage
+            );
 
         var content = new GUIContent(showMessage, GetIconForLog(log));
         return content;
@@ -435,7 +446,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
 
                 foreach(var countedLog in collapsedLinesList)
                 {
-                    var content = GetLogLineGUIContent(countedLog.Log, ShowTimes);
+                    var content = GetLogLineGUIContent(countedLog.Log, ShowTimes, ShowChannels);
                     RenderLogs.Add(countedLog);
                     var logLineSize = logLineStyle.CalcSize(content);
                     LogListMaxWidth = Mathf.Max(LogListMaxWidth, logLineSize.x);
@@ -453,7 +464,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
                 {
                     if(ShouldShowLog(filterRegex, log))
                     {
-                        var content = GetLogLineGUIContent(log, ShowTimes);
+                        var content = GetLogLineGUIContent(log, ShowTimes, ShowChannels);
                         RenderLogs.Add(new CountedLog(log, 1));
                         var logLineSize = logLineStyle.CalcSize(content);
                         LogListMaxWidth = Mathf.Max(LogListMaxWidth, logLineSize.x);
@@ -507,7 +518,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
             }
                 
             //Make all messages single line
-            var content = GetLogLineGUIContent(log, ShowTimes);
+            var content = GetLogLineGUIContent(log, ShowTimes, ShowChannels);
             var drawRect = new Rect(logLineX, buttonY, contentRect.width, LogListLineHeight);
             if(GUI.Button(drawRect, content, logLineStyle))
             {
@@ -905,6 +916,7 @@ public class UberLoggerEditorWindow : EditorWindow, UberLoggerEditor.ILoggerWind
     Texture2D SmallWarningIcon;
     Texture2D SmallMessageIcon;
 
+    bool ShowChannels = true;
     bool ShowTimes = true;
     bool Collapse = false;
     bool ScrollFollowMessages = false;

--- a/UberLoggerChannel.cs
+++ b/UberLoggerChannel.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using System.Collections.Generic;
+using UberLogger;
+using UnityEngine;
+
+/// <summary>
+/// Wraps access to a named channel in a class so that it can be used without having to
+/// type the channel name each time to enforcing channel name checking at compile-time.
+/// </summary>
+public class UberLoggerChannel
+{
+    private string _channelName;
+    public UberLoggerChannel(string channelName)
+    {
+        _channelName = channelName;
+    }
+
+    /// <summary>
+    /// Gets or sets whether messages sent to this channel should actually be relayed to the logging system or not.
+    /// </summary>
+    public bool Mute { get; set; }
+
+    [StackTraceIgnore]
+    public void Log(string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogChannel(_channelName, message, par);
+        }
+    }
+
+    [StackTraceIgnore]
+    public void Log(Object context, string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogChannel(context, _channelName, message, par);
+        }
+    }
+
+    [StackTraceIgnore]
+    public void LogWarning(string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogWarningChannel(_channelName, message, par);
+        }
+    }
+
+    [StackTraceIgnore]
+    public void LogWarning(Object context, string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogWarningChannel(context, _channelName, message, par);
+        }
+    }
+
+    [StackTraceIgnore]
+    public void LogError(string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogErrorChannel(_channelName, message, par);
+        }
+    }
+
+    [StackTraceIgnore]
+    public void LogError(Object context, string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogErrorChannel(context, _channelName, message, par);
+        }
+    }
+}

--- a/UberLoggerChannel.cs.meta
+++ b/UberLoggerChannel.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 6ffc2b9216ac83f4db26a958afcdac7b
+timeCreated: 1519677969
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is really handy if you use channels a lot and want to see output from the various channels in the 'all' pane. Otherwise you can only tell what channel output was sent to in the filtered view (in isolation).