### PR TITLE
Utility class for logging to channel

### DIFF
--- a/Examples/TestUberLogger.cs
+++ b/Examples/TestUberLogger.cs
@@ -78,19 +78,19 @@ public class TestUberLogger : MonoBehaviour
         RunChannelWrapperTests();
 
         // Will hide .Log(...) calls in test function.
-        TestChannelWrapper.Filter = UberLoggerChannel.Filters.HideLogs;
+        TestChannelWrapper.Filter = UberLoggerChannel.Filters.Logs;
         RunChannelWrapperTests();
 
         // Will hide .LogWarning(...) calls in test function.
-        TestChannelWrapper.Filter = UberLoggerChannel.Filters.HideWarnings;
+        TestChannelWrapper.Filter = UberLoggerChannel.Filters.Warnings;
         RunChannelWrapperTests();
 
         // Will hide .LogError(...) calls in test function.
-        TestChannelWrapper.Filter = UberLoggerChannel.Filters.HideErrors;
+        TestChannelWrapper.Filter = UberLoggerChannel.Filters.Errors;
         RunChannelWrapperTests();
 
         // Will hide .Log(...) and LogWarning(...) calls in test function.
-        TestChannelWrapper.Filter = UberLoggerChannel.Filters.HideLogs | UberLoggerChannel.Filters.HideWarnings;
+        TestChannelWrapper.Filter = UberLoggerChannel.Filters.Logs | UberLoggerChannel.Filters.Warnings;
         RunChannelWrapperTests();
     }
 

--- a/Examples/TestUberLogger.cs
+++ b/Examples/TestUberLogger.cs
@@ -4,6 +4,8 @@ using System.Threading;
 
 public class TestUberLogger : MonoBehaviour
 {
+    public static readonly UberLoggerChannel TestChannelWrapper = new UberLoggerChannel("WrapperChannel");
+
     Thread TestThread;
     // Use this for initialization
     void Start ()
@@ -71,6 +73,47 @@ public class TestUberLogger : MonoBehaviour
         UberDebug.LogErrorChannel("Test", "ULogErrorChannel with param {0}", "Test");
         UberDebug.LogErrorChannel(gameObject, "Test", "ULogErrorChannel with GameObject");
         UberDebug.LogErrorChannel(gameObject, "Test", "ULogErrorChannel with GameObject and param {0}", "Test");
+
+        // Will output all messages in test function.
+        RunChannelWrapperTests();
+
+        // Will hide .Log(...) calls in test function.
+        TestChannelWrapper.Filter = UberLoggerChannel.Filters.HideLogs;
+        RunChannelWrapperTests();
+
+        // Will hide .LogWarning(...) calls in test function.
+        TestChannelWrapper.Filter = UberLoggerChannel.Filters.HideWarnings;
+        RunChannelWrapperTests();
+
+        // Will hide .LogError(...) calls in test function.
+        TestChannelWrapper.Filter = UberLoggerChannel.Filters.HideErrors;
+        RunChannelWrapperTests();
+
+        // Will hide .Log(...) and LogWarning(...) calls in test function.
+        TestChannelWrapper.Filter = UberLoggerChannel.Filters.HideLogs | UberLoggerChannel.Filters.HideWarnings;
+        RunChannelWrapperTests();
+    }
+
+    private void RunChannelWrapperTests()
+    {
+        Debug.Log("Running Channel Wrapper Tests...");
+
+        TestChannelWrapper.Log("Wrapped Channel");
+        TestChannelWrapper.Log("Wrapped Channel with param {0}", "Test");
+        TestChannelWrapper.Log(gameObject, "Wrapped Channel with GameObject");
+        TestChannelWrapper.Log(gameObject, "Wrapped Channel with GameObject and param {0}", "Test");
+
+        TestChannelWrapper.LogWarning("Wrapped Channel Warning");
+        TestChannelWrapper.LogWarning("Wrapped Channel Warning with param {0}", "Test");
+        TestChannelWrapper.LogWarning(gameObject, "Wrapped Channel Warning with GameObject");
+        TestChannelWrapper.LogWarning(gameObject, "Wrapped Channel Warning with GameObject and param {0}", "Test");
+
+        TestChannelWrapper.LogError("Wrapped Channel Error");
+        TestChannelWrapper.LogError("Wrapped Channel Error with param {0}", "Test");
+        TestChannelWrapper.LogError(gameObject, "Wrapped Channel Error with GameObject");
+        TestChannelWrapper.LogError(gameObject, "Wrapped Channel Error with GameObject and param {0}", "Test");
+
+        Debug.Log("... Done Running Channel Wrapper Tests.");
     }
 	
 	// Update is called once per frame

--- a/UberLoggerChannel.cs
+++ b/UberLoggerChannel.cs
@@ -9,10 +9,10 @@ using UnityEngine;
 /// </summary>
 public class UberLoggerChannel
 {
-    private string _channelName;
+    private string ChannelName;
     public UberLoggerChannel(string channelName)
     {
-        _channelName = channelName;
+        ChannelName = channelName;
         Filter = Filters.None;
     }
 
@@ -23,9 +23,9 @@ public class UberLoggerChannel
     public enum Filters
     {
         None = 0,
-        HideLogs = 1,
-        HideWarnings = 2,
-        HideErrors = 4
+        Logs = 1 << 0,
+        Warnings = 1 << 1,
+        Errors = 1 << 2
     }
 
     /// <summary>
@@ -36,54 +36,54 @@ public class UberLoggerChannel
     [StackTraceIgnore]
     public void Log(string message, params object[] par)
     {
-        if ((Filter & Filters.HideLogs) != Filters.HideLogs)
+        if ((Filter & Filters.Logs) == 0)
         {
-            UberDebug.LogChannel(_channelName, message, par);
+            UberDebug.LogChannel(ChannelName, message, par);
         }
     }
 
     [StackTraceIgnore]
     public void Log(Object context, string message, params object[] par)
     {
-        if ((Filter & Filters.HideLogs) != Filters.HideLogs)
+        if ((Filter & Filters.Logs) == 0)
         {
-            UberDebug.LogChannel(context, _channelName, message, par);
+            UberDebug.LogChannel(context, ChannelName, message, par);
         }
     }
 
     [StackTraceIgnore]
     public void LogWarning(string message, params object[] par)
     {
-        if ((Filter & Filters.HideWarnings) != Filters.HideWarnings)
+        if ((Filter & Filters.Warnings) == 0)
         {
-            UberDebug.LogWarningChannel(_channelName, message, par);
+            UberDebug.LogWarningChannel(ChannelName, message, par);
         }
     }
 
     [StackTraceIgnore]
     public void LogWarning(Object context, string message, params object[] par)
     {
-        if ((Filter & Filters.HideWarnings) != Filters.HideWarnings)
+        if ((Filter & Filters.Warnings) == 0)
         {
-            UberDebug.LogWarningChannel(context, _channelName, message, par);
+            UberDebug.LogWarningChannel(context, ChannelName, message, par);
         }
     }
 
     [StackTraceIgnore]
     public void LogError(string message, params object[] par)
     {
-        if ((Filter & Filters.HideErrors) != Filters.HideErrors)
+        if ((Filter & Filters.Errors) == 0)
         {
-            UberDebug.LogErrorChannel(_channelName, message, par);
+            UberDebug.LogErrorChannel(ChannelName, message, par);
         }
     }
 
     [StackTraceIgnore]
     public void LogError(Object context, string message, params object[] par)
     {
-        if ((Filter & Filters.HideErrors) != Filters.HideErrors)
+        if ((Filter & Filters.Errors) == 0)
         {
-            UberDebug.LogErrorChannel(context, _channelName, message, par);
+            UberDebug.LogErrorChannel(context, ChannelName, message, par);
         }
     }
 }

--- a/UberLoggerChannel.cs
+++ b/UberLoggerChannel.cs
@@ -13,17 +13,30 @@ public class UberLoggerChannel
     public UberLoggerChannel(string channelName)
     {
         _channelName = channelName;
+        Filter = Filters.None;
     }
 
     /// <summary>
-    /// Gets or sets whether messages sent to this channel should actually be relayed to the logging system or not.
+    /// Filters for preventing display of certain message types.
     /// </summary>
-    public bool Mute { get; set; }
+    [System.Flags]
+    public enum Filters
+    {
+        None = 0,
+        HideLogs = 1,
+        HideWarnings = 2,
+        HideErrors = 4
+    }
+
+    /// <summary>
+    /// Gets or sets the current filters being applied to this channel. Messages that match the specified set of flags will be ignored.
+    /// </summary>
+    public Filters Filter { get; set; }
 
     [StackTraceIgnore]
     public void Log(string message, params object[] par)
     {
-        if (!Mute)
+        if ((Filter & Filters.HideLogs) != Filters.HideLogs)
         {
             UberDebug.LogChannel(_channelName, message, par);
         }
@@ -32,7 +45,7 @@ public class UberLoggerChannel
     [StackTraceIgnore]
     public void Log(Object context, string message, params object[] par)
     {
-        if (!Mute)
+        if ((Filter & Filters.HideLogs) != Filters.HideLogs)
         {
             UberDebug.LogChannel(context, _channelName, message, par);
         }
@@ -41,7 +54,7 @@ public class UberLoggerChannel
     [StackTraceIgnore]
     public void LogWarning(string message, params object[] par)
     {
-        if (!Mute)
+        if ((Filter & Filters.HideWarnings) != Filters.HideWarnings)
         {
             UberDebug.LogWarningChannel(_channelName, message, par);
         }
@@ -50,7 +63,7 @@ public class UberLoggerChannel
     [StackTraceIgnore]
     public void LogWarning(Object context, string message, params object[] par)
     {
-        if (!Mute)
+        if ((Filter & Filters.HideWarnings) != Filters.HideWarnings)
         {
             UberDebug.LogWarningChannel(context, _channelName, message, par);
         }
@@ -59,7 +72,7 @@ public class UberLoggerChannel
     [StackTraceIgnore]
     public void LogError(string message, params object[] par)
     {
-        if (!Mute)
+        if ((Filter & Filters.HideErrors) != Filters.HideErrors)
         {
             UberDebug.LogErrorChannel(_channelName, message, par);
         }
@@ -68,7 +81,7 @@ public class UberLoggerChannel
     [StackTraceIgnore]
     public void LogError(Object context, string message, params object[] par)
     {
-        if (!Mute)
+        if ((Filter & Filters.HideErrors) != Filters.HideErrors)
         {
             UberDebug.LogErrorChannel(context, _channelName, message, par);
         }

--- a/UberLoggerChannel.cs
+++ b/UberLoggerChannel.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using System.Collections.Generic;
+using UberLogger;
+using UnityEngine;
+
+/// <summary>
+/// Wraps access to a named channel in a class so that it can be used without having to
+/// type the channel name each time to enforcing channel name checking at compile-time.
+/// </summary>
+public class UberLoggerChannel
+{
+    private string _channelName;
+    public UberLoggerChannel(string channelName)
+    {
+        _channelName = channelName;
+    }
+
+    /// <summary>
+    /// Gets or sets whether messages sent to this channel should actually be relayed to the logging system or not.
+    /// </summary>
+    public bool Mute { get; set; }
+
+    [StackTraceIgnore]
+    public void Log(string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogChannel(_channelName, message, par);
+        }
+    }
+
+    [StackTraceIgnore]
+    public void Log(Object context, string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogChannel(context, _channelName, message, par);
+        }
+    }
+
+    [StackTraceIgnore]
+    public void LogWarning(string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogWarningChannel(_channelName, message, par);
+        }
+    }
+
+    [StackTraceIgnore]
+    public void LogWarning(Object context, string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogWarningChannel(context, _channelName, message, par);
+        }
+    }
+
+    [StackTraceIgnore]
+    public void LogError(string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogErrorChannel(_channelName, message, par);
+        }
+    }
+
+    [StackTraceIgnore]
+    public void LogError(Object context, string message, params object[] par)
+    {
+        if (!Mute)
+        {
+            UberDebug.LogErrorChannel(context, _channelName, message, par);
+        }
+    }
+}

--- a/UberLoggerChannel.cs.meta
+++ b/UberLoggerChannel.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 6ffc2b9216ac83f4db26a958afcdac7b
+timeCreated: 1519677969
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a utility class that wraps calls to Log*Channel(...) so that you can get code completion and don't have to worry about typing the channel name correctly each time.

My use case looks like this:
1) Make a static class with a number of UberLoggerChannel as members:
```
public static class Logger {
    public static readonly UberLoggerChannel Core = new UberLoggerChannel("Core");
    public static readonly UberLoggerChannel Achievements = new UberLoggerChannel("Achievements ");
    // .... More channels
}
```

Then usage looks like:
```
Logger.Core.Log("Foo");
Logger.Achievements.LogWarning("Bar");
```

And you get compile-time support (code completion, error checking, find-references, etc..). This is really useful when you want to standardize the usage of channels across a team because you don't have to remember capitalization and channel names.

Also you can easily turn on/off these channels without sprinkling your code with `if (muteMyChannel) { Debug.Log("...."); }` checks:

For example:
```
public static class Logger {
    public static readonly UberLoggerChannel ObscureSystem = new UberLoggerChannel("ObscureSystem");
    // ... Other channels

    static Logger() {
        ObscureSystem.Mute = true;
    }
};
```