### PR TITLE
Advertising some UberLogger add-ons

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ And the in-game version looks like this:
   UberConsole.
 * Pull requests welcome!
 
+## Extensions
+* [UberLogger-StructuredFile](https://github.com/falldamagestudio/UberLogger-StructuredFile)
+  adds a structured log file format with timestamps, channel names, and control over which
+  log messages are printed with callstacks and which are printed without.
+* [UberLogger-Stackdriver](https://github.com/falldamagestudio/UberLogger-Stackdriver)
+  adds centralized logging. Log messages will be sent from game clients to Google's
+  Stackdriver service. The collected logs can be browsed and searched in the Stackdriver web UI.
+* [UberLogger-LogChannels](https://github.com/falldamagestudio/UberLogger-LogChannels)
+  adds compile-time resolution and muting of log channels. This is useful for very large
+  projects where logging to muted channels causes performance problems.
+  
  * * * *
 
-[UberLogger]: https://github.com/bbbscarter/UberLogger
+UberLogger: https://github.com/bbbscarter/UberLogger


### PR DESCRIPTION
I would like to make visible some of the extensions that I have written. UberLogger-StructuredFile in particular is something that I think would be beneficial to many others.

How about adding them to a section of the readme like this? If not, is there some other reasonable way that others can discover the extensions from the UberLogger core repo?