### PR TITLE
Optimize Editor console

### DIFF
--- a/UberLoggerEditor.cs
+++ b/UberLoggerEditor.cs
@@ -144,11 +144,11 @@ public class UberLoggerEditor : ScriptableObject, UberLogger.ILogger
         }
     }
 
-    public List<LogInfo> CopyLogInfo()
+    public void CopyLogInfoTo(List<LogInfo> container)
     {
         lock(this)
         {
-            return new List<LogInfo>(LogInfo);
+            container.AddRange(LogInfo);
         }
     }
 


### PR DESCRIPTION
- Make all lines fixed height
- Add full message in details section
- Only update new log lines if filters didn't change (that was performance bottle neck)
- Cache gui styles

This modifications could made work with UberLogger much easier in Editor by very little redesign cost (#39).
But it's still has very bad performance, mostly cause of processing stackTrace just after log call.
It's actually not so necessary, cause you need access to separate stack trace lines only on line select (or I'm missing smth?). Any way, that optimization would need much more time and changes to core logic...